### PR TITLE
Make sure UI Thread is not finishing

### DIFF
--- a/aware-core/src/main/java/com/aware/ui/ESM_Queue.java
+++ b/aware-core/src/main/java/com/aware/ui/ESM_Queue.java
@@ -70,7 +70,8 @@ public class ESM_Queue extends FragmentActivity {
         
         if( getQueueSize(getApplicationContext()) > 0 ) {
             DialogFragment esm = new ESM_UI();
-            esm.show(fragmentManager, TAG);
+            if (!isFinishing())
+            	esm.show(fragmentManager, TAG);
             if( ! powerManager.isScreenOn() ) {
                 vibrator.vibrate(777);
             }


### PR DESCRIPTION
Sometimes when you try to spawn a dialog box from the background thread and the foreground thread is recycling the dialog creation will fail! We need to add this check to make sure we avoid errors like this

Unable to resume activity {com.aware/com.aware.ui.ESM_Queue}: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@6f047c9 is not valid; is your activity running?
